### PR TITLE
Display GPU name to user after device selection

### DIFF
--- a/rootfs/golemwz.py
+++ b/rootfs/golemwz.py
@@ -813,9 +813,7 @@ def main(args, wizard_conf, wizard_dialog):
                 break
 
         if selected_gpu:
-            wizard_dialog.msgbox(
-                f"Selected GPU: {selected_gpu['slot']} (VFIO: {selected_gpu['vfio']})"
-            )
+            wizard_dialog.msgbox(f"Selected GPU: {selected_gpu['description']}")
 
         if not code or not selected_gpu:
             raise WizardError("Invalid GPU selection.")


### PR DESCRIPTION
Previously presented values were not usable for the end user.
The idea for this change is to display something that the user can comprehend.